### PR TITLE
docker-compose.yml publish TCPServerRouter on host via bridge net

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -3,7 +3,13 @@ networks:
   pdc-net:
     ipam:
       config:
-        - subnet: 172.20.0.0/24
+        - subnet: 172.20.0.0/16
+  bridge-net:
+    driver: bridge
+    ipam:
+      config:
+        - subnet: 172.22.0.0/16
+
 services:
   serverrouter:
     build: .
@@ -11,6 +17,9 @@ services:
     networks:
       pdc-net:
         ipv4_address: 172.20.0.5
+      bridge-net:
+        ipv4_address: 172.22.0.5
+
     ports:
       - "5555:5555"
       - "5555:5555/udp"

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -11,6 +11,9 @@ services:
     networks:
       pdc-net:
         ipv4_address: 172.20.0.5
+    ports:
+      - "5555:5555"
+      - "5555:5555/udp"
   server:
     build: .
     command: TCPServer
@@ -19,6 +22,7 @@ services:
     networks:
       pdc-net:
         ipv4_address: 172.20.0.6
+
   client:
     build: .
     command: TCPClient

--- a/run.ps1
+++ b/run.ps1
@@ -1,0 +1,21 @@
+
+$SrcDir = "${PSScriptRoot}\src"
+$BuildDir = "${PSScriptRoot}\build"
+
+Push-Location $PSScriptRoot
+
+if (!(Test-Path -Path $BuildDir)) {
+    New-Item -ItemType Directory -Path $BuildDir
+}
+
+javac.exe -d $BuildDir $SrcDir\*.java
+if ($LASTEXITCODE -ne 0) {
+    throw "Compile failed."
+}
+
+$Program = $args[0]
+if (!($Program)) {
+    throw "Empty program argument!"
+}
+
+java.exe -cp $BuildDir $Program


### PR DESCRIPTION
# docker-compose.yml port 555 publish on host

This PR adds a new bridge network, `bridge-net` with subnet `172.22.0.0/16` using the docker bridge network mode. Only the `TCPServerRouter` is added to this new network. It also modifies the existing `pdc-net`and reduces its subnet mask to `172.20.0.0/16`

This makes forwards port 5555 on the TCPServerRouter container to+from port 5555 on the host's network interface. This will make it usable from external clients while the docker compose stack is running