### PR TITLE
docker-compose.yml change subnets to avoid conflict on Wilder server

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -19,7 +19,6 @@ services:
         ipv4_address: 172.23.0.5
       bridge-net:
         ipv4_address: 172.24.0.5
-
     ports:
       - "5555:5555"
       - "5555:5555/udp"

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -3,12 +3,12 @@ networks:
   pdc-net:
     ipam:
       config:
-        - subnet: 172.20.0.0/16
+        - subnet: 172.23.0.0/16
   bridge-net:
     driver: bridge
     ipam:
       config:
-        - subnet: 172.22.0.0/16
+        - subnet: 172.24.0.0/16
 
 services:
   serverrouter:
@@ -16,9 +16,9 @@ services:
     command: TCPServerRouter
     networks:
       pdc-net:
-        ipv4_address: 172.20.0.5
+        ipv4_address: 172.23.0.5
       bridge-net:
-        ipv4_address: 172.22.0.5
+        ipv4_address: 172.24.0.5
 
     ports:
       - "5555:5555"
@@ -30,7 +30,7 @@ services:
       - serverrouter
     networks:
       pdc-net:
-        ipv4_address: 172.20.0.6
+        ipv4_address: 172.23.0.6
 
   client:
     build: .
@@ -40,4 +40,4 @@ services:
       - server
     networks:
       pdc-net:
-        ipv4_address: 172.20.0.7
+        ipv4_address: 172.23.0.7


### PR DESCRIPTION
The wilder server's LAN IP is 192.168.0.112

To make a quick lab for testing, I've modified the `docker-compose.yaml` to publish the TCPServerRouter on port 5555

This will make it usable on external clients

This MR changes the subnets so they do not confilct with existing containers on the Wilder server

